### PR TITLE
Transactional syncing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 examples/
+.idea


### PR DESCRIPTION
We started to use this tool more intensively and we need more robust approach for syncing files. In this PR two features added:

1. You can pass existent pg.Client to pgcodebase. It's very useful for migrations (we use sequeilze migrations), since you can pass connection with existent transaction to pgcodebase like this:

```js
queryInterface.sequelize.transaction(async (transaction) => {
  await pgcodebase({
    client: transaction.connection,
    dir: path.join(__dirname, '../src/sql'),
    schema: 'public',
    dropOnly: true,
  });

  // Migration itself goes here

  await pgcodebase({
    client: transaction.connection,
    dir: path.join(__dirname, '../src/sql'),
    schema: 'public',
    createOnly: true,
  });
}),
```

I think it will be applicable for any library using `pg` under the hood.

2. `pgcodebase` sync files in transaction by default. It allows to run it on different envs without downtime when some functions, triggers, views do not exist. Also it automatically rollback changes if there are some syntax error in the files.

Alos small bug fix is here: connection is closed even if errors occurred.

Todo:
- [ ] update docs