### PR TITLE
Adding support of folder requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Options:
 
 If `createOnly` or `dropOnly` is true, then the script will only create or only drop entities respectively. It is useful to specify `dropOnly` before table migrations and `createOnly` after.
 
-You can also configure pgcodebase using `.env` file. You will have to create `.env` file in the directory where you execute the command. In `.env` there may be variables `PGUSER`, `PGHOST`, `PGPASSWORD`, `PGDATABASE`, `PGPORT`, `PGCODEBASE_CONNECTION_STRING` and `PGCODEBASE_DIR`. Last one should contain an absolute or relative path to the directory with functions, triggers and views. Other variables (except for [`PGCODEBASE_CONNECTION_STRING`](https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-CONNSTRING)) are [standard for postgresql](https://www.postgresql.org/docs/9.3/static/libpq-envars.html).
+You can also configure pgcodebase using `.env` file. You will have to create `.env` file in the directory where you execute the command. In `.env` there may be variables `PGUSER`, `PGHOST`, `PGPASSWORD`, `PGDATABASE`, `PGPORT`, `PGCODEBASE_CONNECTION_STRING` and `PGCODEBASE_DIR`. Last one should contain an absolute or relative path to the directory with functions, triggers, grants and views. Other variables (except for [`PGCODEBASE_CONNECTION_STRING`](https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-CONNSTRING)) are [standard for postgresql](https://www.postgresql.org/docs/9.3/static/libpq-envars.html).
 
 # Problem
 
-Have you ever worked with postgresql functions, triggers and views using migrations? It becomes increasingly complex when your codebase grows. If you want to change the signature of some function, postgresql requires you to drop and recreate all the functions that depend on your function.
+Have you ever worked with postgresql functions, triggers, grants and views using migrations? It becomes increasingly complex when your codebase grows. If you want to change the signature of some function, postgresql requires you to drop and recreate all the functions that depend on your function.
 
 Let me demonstrate you on an example. Usually you would create migrations to create functions. [Migration 1](./examples/bad/1_create_function_bar.sql) and [Migration 2](./examples/bad/2_create_function_foo.sql). Notice that function `foo` calls function `bar` therefore a dependency exists. Then if you need to modify body of the `bar` you will need to drop and recreate both functions: [Migration 3](./examples/bad/3_modify_function_bar.sql). Imagine now you have multiple functions that depend on `bar()`. You will have to drop and recreate them all! This process becomes really painful as your codebase grows.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ If, for example, function `baz()` depends on function `foo(bar integer)` at the 
 ```
 Note that the path is relative to your `dir` and also `drop-code` and `require`s (you can specify multiple) can be in any order at the start of a file.
 
+Also folder require is supported
+```
+--- required functions
+```
+In this case all folder files would be required as dependencies.
+
 # Inspiration
 
 This tool was inspired by [PgRebase](https://github.com/oelmekki/pgrebase). PgRebase, however, cannot process dependencies between different types of entities. If you have a view that depends on some function, you are out of luck. Pgcodebase doesn't care about the types of your entities. It can create and drop them in any order specified with `require`s.


### PR DESCRIPTION
## Issue:

Single sql file may be dependent on multiple other files. AS an example:
`/grants/app.sql` may be dependent on all `/views/*.sql` files

## Solution:
If `required` line value is a directory, all files are treated as dependencies


## Usage example

```sql

-- require views
      
grant select on table users to app;
```

Equivalent to:

```sql

-- require views/view1.sql
-- require views/view2.sql
-- and etc.
      
grant select on table users to app;
```
