### PR TITLE
Upgrading pg version to support Node 14+

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commander": "^2.15.1",
     "dotenv": "^5.0.1",
     "fs-extra": "^5.0.0",
-    "pg": "^7.4.1",
+    "pg": "^8.5.1",
     "recursive-readdir": "^2.2.2"
   },
   "keywords": [


### PR DESCRIPTION
This PR allow pgcodebase work on Node 14+

see https://github.com/brianc/node-postgres/issues/2180